### PR TITLE
[Naitie] Fix: Display

### DIFF
--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -14,4 +14,23 @@ module OrdersHelper
     end
     result.unshift [t("orders.voucher_form.select_voucher"), 0]
   end
+
+  def can_delete? order
+    order.pending? || order.cancelling?
+  end
+
+  def order_status_class status
+    case status
+    when "approved"
+      "text-green-500"
+    when "pending"
+      "text-yellow"
+    when "cancelling"
+      "text-orange-500"
+    when "cancel"
+      "text-red-500"
+    else
+      "text-gray-500"
+    end
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,4 +2,8 @@ module UsersHelper
   def admin
     @admin = User.find_by admin: true
   end
+
+  def activated_class activated
+    activated ? "text-green-500" : "text-red-500"
+  end
 end

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['toast']
+
+  connect() {
+    setTimeout(() => {
+      this.hide()
+    }, 3000)
+  }
+
+  hide() {
+    this.toastTarget.classList.add('opacity-0')
+    this.toastTarget.classList.add('translate-y-4')
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,7 +160,7 @@ source: :field
 
     return unless types < Settings.min_password_types
 
-    errors.add :password, I18n.t("users.create.password_complexity")
+    errors.add :base, I18n.t("users.create.password_complexity")
   end
 
   def create_activity

--- a/app/views/booking_history/_filter.html.erb
+++ b/app/views/booking_history/_filter.html.erb
@@ -2,19 +2,19 @@
   <div class="flex items-center gap-x-12">
     <div class="flex flex-col">
       <%= f.label :field, t("orders.filter.field"), class: "mb-1 font-medium text-gray-700" %>
-      <%= f.search_field :field, class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
+      <%= f.search_field :field, value: params[:field], class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
     </div>
 
     <div class="flex flex-col">
       <%= f.label :date, t("orders.filter.date"), class: "mb-1 font-medium text-gray-700" %>
-      <%= f.date_field :date, class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
+      <%= f.date_field :date, value: params[:date], class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
     </div>
 
     <div class="flex flex-col">
       <%= f.label :status, t("orders.filter.status"), class: "mb-1 font-medium text-gray-700" %>
       <%= f.select :status,
-                  OrderField.statuses.to_a.map {|status| [status[0].humanize, status[1]]},
-                  {include_blank: true},
+                  OrderField.statuses.keys.map {|status| [t("activerecord.attributes.order_field.status.#{status}"), OrderField.statuses[status]]},
+                  {include_blank: true, selected: params[:status]},
                   class: "pl-3 pr-8 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary cursor-pointer" %>
     </div>
     <div class="flex flex-col">

--- a/app/views/booking_history/_user_order.html.erb
+++ b/app/views/booking_history/_user_order.html.erb
@@ -5,7 +5,9 @@
   <td class="px-4 py-2 buser_order-b buser_order-gray-300 text-center"><%= user_order.started_time.strftime(Settings.time_format) %></td>
   <td class="px-4 py-2 buser_order-b buser_order-gray-300 text-center"><%= user_order.finished_time.strftime(Settings.time_format) %></td>
   <td class="px-4 py-2 buser_order-b buser_order-gray-300 text-center"><%= exchange_money(user_order.final_price) %></td>
-  <td class="px-4 py-2 buser_order-b buser_order-gray-300 text-center"><%= user_order.status %></td>
+  <td class="px-4 py-2 buser_order-b buser_order-gray-300 text-center <%= order_status_class(user_order.status) %>">
+    <%= t "activerecord.attributes.order_field.status.#{user_order.status}" %>
+  </td>
   <td class="px-4 py-2 buser_order-b buser_order-gray-300 text-center"><%= user_order.created_at.strftime(Settings.date_time_format) %></td>
   <td class="px-4 py-2 buser_order-b buser_order-gray-300 text-center"><%= user_order.updated_at.strftime(Settings.date_time_format) %></td>
   <td class="px-4 py-2 buser_order-b buser_order-gray-300 text-center">

--- a/app/views/fields/_filters.html.erb
+++ b/app/views/fields/_filters.html.erb
@@ -8,7 +8,7 @@
     <%= t ".price" %>
     <%= fa_icon "caret-down", class: "ml-2 text-gray-500" %>
   </button>
-  <div id="filter-price-list" class="flex flex-col absolute hidden shadow-lg">
+  <div id="filter-price-list" class="flex-col absolute hidden shadow-lg">
     <%= render "filter_btn", active_params: {order: :default_price, sort: :asc}, label: t(".low_to_high"), not_rounded: true %>
     <%= render "filter_btn", active_params: {order: :default_price, sort: :desc}, label: t(".high_to_low"), not_rounded: true %>
   </div>
@@ -19,7 +19,7 @@
     <%= t ".type" %>
     <%= fa_icon "caret-down", class: "ml-2 text-gray-500" %>
   </button>
-  <div id="filter-type-list" class="flex flex-col absolute hidden shadow-lg">
+  <div id="filter-type-list" class="flex-col hidden absolute shadow-lg">
     <%= render "filter_btn", active_params: {type: :all}, label: t(".all"), not_rounded: true %>
     <% all_field_types.each do |type| %>
       <%= render "filter_btn", active_params: {type: type.id}, label: type.name, not_rounded: true %>

--- a/app/views/orders/_filter.html.erb
+++ b/app/views/orders/_filter.html.erb
@@ -2,24 +2,24 @@
   <div class="flex items-center gap-x-12">
     <div class="flex flex-col">
       <%= f.label :user, t(".user"), class: "mb-1 font-medium text-gray-700" %>
-      <%= f.search_field :user, class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
+      <%= f.search_field :user, value: params[:user], class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
     </div>
 
     <div class="flex flex-col">
       <%= f.label :field, t(".field"), class: "mb-1 font-medium text-gray-700" %>
-      <%= f.search_field :field, class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
+      <%= f.search_field :field, value: params[:field], class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
     </div>
 
     <div class="flex flex-col">
       <%= f.label :date, t(".date"), class: "mb-1 font-medium text-gray-700" %>
-      <%= f.date_field :date, class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
+      <%= f.date_field :date, value: params[:date], class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
     </div>
 
     <div class="flex flex-col">
       <%= f.label :status, t(".status"), class: "mb-1 font-medium text-gray-700" %>
       <%= f.select :status,
-                  OrderField.statuses.to_a.map {|status| [status[0].humanize, status[1]]},
-                  {include_blank: true},
+                  OrderField.statuses.keys.map {|status| [t("activerecord.attributes.order_field.status.#{status}"), OrderField.statuses[status]]},
+                  {include_blank: true, selected: params[:status]},
                   class: "pl-3 pr-8 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary cursor-pointer" %>
     </div>
     <div class="flex flex-col">

--- a/app/views/orders/_order.html.erb
+++ b/app/views/orders/_order.html.erb
@@ -6,12 +6,14 @@
   <td class="px-4 py-2 border-b border-gray-300 text-center"><%= order.started_time.strftime(Settings.time_format) %></td>
   <td class="px-4 py-2 border-b border-gray-300 text-center"><%= order.finished_time.strftime(Settings.time_format) %></td>
   <td class="px-4 py-2 border-b border-gray-300 text-center"><%= exchange_money(order.final_price) %></td>
-  <td class="px-4 py-2 border-b border-gray-300 text-center"><%= order.status %></td>
-  <td class="px-4 py-2 border-b border-gray-300 text-center"><%= order.created_at.strftime(Settings.date_time_format) %></td>
-  <td class="px-4 py-2 border-b border-gray-300 text-center"><%= order.updated_at.strftime(Settings.date_time_format) %></td>
+  <td class="px-4 py-2 border-b border-gray-300 text-center w-32 <%= order_status_class(order.status) %>">
+    <%= t "activerecord.attributes.order_field.status.#{order.status}" %>
+  </td>
+  <td class="px-4 py-2 border-b border-gray-300 text-center w-16"><%= order.created_at.strftime(Settings.date_time_format) %></td>
+  <td class="px-4 py-2 border-b border-gray-300 text-center w-16"><%= order.updated_at.strftime(Settings.date_time_format) %></td>
   <td class="px-4 py-2 border-b border-gray-300 text-center">
     <div class="mb-2"><%= link_to t("orders.table.show"), order_path(order), class: "text-blue-600 hover:underline" %></div>
-    <% unless order.cancel? %>
+    <% if can_delete? order %>
       <div><%= link_to t("orders.table.destroy"), order_path(order, order_field: {status: :cancel} ),
                 data: { "turbo-method": :patch, turbo_confirm: t("orders.edit.confirm") },
                 class: "text-red-600 hover:underline" %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -4,10 +4,10 @@
   <h1 class="text-3xl font-bold text-center"><%= t ".order" %></h1>
   <h3 class="text-2xl font-semibold text-center"><%= t ".order_id", order_id: @order.id %></h1>
   <p class="text-2xl font-medium text-center text-primary"><%= t ".field" %><%= link_to @order.field.name, @order.field %>
-  <p class="text-2xl font-medium text-center text-secondary"><%= t ".user" %><%= link_to @order.user.name, @order.user %>
-  <p class="text-2xl font-medium text-center text-red-400"><%= t ".status" %><%= @order.status %>
+  <p class="text-2xl font-medium text-center text-indigo-500"><%= t ".user" %><%= link_to @order.user.name, @order.user %>
+  <p class="text-2xl font-medium text-center <%= order_status_class(@order.status) %>"><%= t ".status" %><%= @order.status %>
   <%= render "bill" %>
-  <% unless @order.cancel? %>
+  <% if can_delete? @order %>
     <%= render "cancel_button" %>
   <% end %>
 </div>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,15 +1,23 @@
-<% flash.each do |type, message| %>
-  <% alert_type = case type.to_sym %>
-    <% when :success then "bg-green-100 border-green-500 text-green-700" %>
-    <% when :danger then "bg-red-100 border-red-500 text-red-700" %>
-    <% when :info then "bg-blue-100 border-blue-500 text-blue-700" %>
-    <% when :warning then "bg-yellow-100 border-yellow-500 text-yellow-700" %>
-    <% else "bg-gray-100 border-gray-500 text-gray-700" %>
-  <% end %>
+<div data-controller="toast", class="text-3xl">
+  <% flash.each do |type, message| %>
+    <% alert_type, icon_class = case type.to_sym
+         when :success
+           ["bg-green-100 border-green-500 text-green-700", "fa fa-check-circle text-green-500"]
+         when :danger
+           ["bg-red-100 border-red-500 text-red-700", "fa fa-exclamation-circle text-red-500"]
+         when :info
+           ["bg-blue-100 border-blue-500 text-blue-700", "fa fa-info-circle text-blue-500"]
+         when :warning
+           ["bg-yellow-100 border-yellow-500 text-yellow-700", "fa fa-exclamation-triangle text-yellow-500"]
+         else
+           ["bg-gray-100 border-gray-500 text-gray-700", "fa fa-info-circle text-gray-500"]
+       end %>
 
-  <div class="border-t-4 rounded-b px-4 py-4 shadow-md <%= alert_type %>">
-    <div class="container">
-      <p class="font-bold text-lg"><%= message %></p>
+    <div class="fixed bottom-4 right-4 z-50 rounded-lg px-2 py-4 shadow-md <%= alert_type %>" data-toast-target="toast" data-action="transitionend->toast#hide">
+      <div class="container flex items-center">
+        <i class="<%= icon_class %> mr-2"></i>
+        <p class="font-bold text-base"><%= message %></p>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/users/_filter.html.erb
+++ b/app/views/users/_filter.html.erb
@@ -2,20 +2,20 @@
   <div class ="flex items-center gap-x-12">
     <div class="flex flex-col">
       <%= f.label :name, t("users.table.name"), class: "mb-1 font-medium text-gray-700" %>
-      <%= f.search_field :name, class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
+      <%= f.search_field :name, value: params[:name], class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
     </div>
 
     <div class="flex flex-col">
       <%= f.label :email, t("users.table.email"), class: "mb-1 font-medium text-gray-700" %>
-      <%= f.search_field :email, class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
+      <%= f.search_field :email, value: params[:email], class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
     </div>
 
     <div class="flex flex-col">
       <%= f.label :activated, t("users.table.activated"), class: "mb-1 font-medium text-gray-700" %>
       <%= f.select :activated,
                   [[t(".active"), true], [t(".inactive"), false]],
-                  { include_blank: true },
-                  class: "px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
+                  {include_blank: true, selected: params[:activated]},
+                  class: "pr-8 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" %>
     </div>
     <div class="flex flex-col">
       <%= f.submit t(".search"), class: "w-full mt-6 px-4 py-2 text-white bg-primary rounded-md hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary cursor-pointer" %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -3,7 +3,9 @@
   <td class="px-4 py-2 border-b border-gray-300 text-center"><%= user.name %></td>
   <td class="px-4 py-2 border-b border-gray-300 text-center"><%= user.email %></td>
   <td class="px-4 py-2 border-b border-gray-300 text-center"><%= exchange_money(user.money) %></td>
-  <td class="px-4 py-2 border-b border-gray-300 text-center"><%= user.activated %></td>
+  <td class="px-4 py-2 border-b border-gray-300 text-center <%= activated_class(user.activated) %>">
+    <%= t "activerecord.attributes.user.activated.#{user.activated}" %>
+  </td>
   <td class="px-4 py-2 border-b border-gray-300 text-center"><%= user.created_at.strftime(Settings.date_time_format) %></td>
   <td class="px-4 py-2 border-b border-gray-300 text-center">
     <div class="mb-2"><%= link_to t(".show"), user, class: "text-blue-600 hover:underline" %></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,11 @@ en:
         date: "Date"
         started_time: "Start time"
         finished_time: "Finish time"
+        status:
+          approved: "Approved"
+          pending: "Pending"
+          cancelling: "Cancelling"
+          cancel: "Cancel"
       field:
         name: "Field name"
         default_price: "Default price"
@@ -376,3 +381,11 @@ en:
         close_time: "Close time"
         description: "Description"
         image: "Image"
+      user:
+        activated:
+          true: "True"
+          false: "False"
+        name: "Name"
+        password: "Password"
+        email: "Email"
+        password_confirmation: "Password confirmation"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -367,6 +367,11 @@ vi:
         date: "Ngày"
         started_time: "Thời gian bắt đầu"
         finished_time: "Thời gian kết thúc"
+        status:
+          approved: "Chấp thuận"
+          pending: "Đang chờ"
+          cancelling: "Đang hủy"
+          cancel: "Đã hủy"
       field:
         name: "Tên sân"
         default_price: "Giá mặc định"
@@ -374,3 +379,11 @@ vi:
         close_time: "Giờ đóng cửa"
         description: "Mô tả"
         image: "Hình ảnh"
+      user:
+        activated:
+          true: "Đúng"
+          false: "Sai"
+        name: "Tên"
+        password: "Mật khẩu"
+        email: "Email"
+        password_confirmation: "Mật khẩu xác nhận"


### PR DESCRIPTION
## Checklist tự review pull trước khi ready nhờ trainer review
- [x] Kiểm tra mỗi pull request 1 commit, nếu nhiều commit thì hãy gộp commit thành 1 rồi đẩy lại lên git
- [x] Trong các file của rails (đuôi .erb, .rb, .yml): sử dụng nháy " thay vì nháy '
- [x] Trong file javascript: sử dụng nháy ' thay vì "
- [x] Sử dụng thụt lề 2 space (setting lại vscode /sublime text nếu chưa cài đặt)
- [x] Cuối mỗi file kiểm tra có end line (khi đẩy lên git xem file change k bị lỗi tròn đỏ ở cuối file)
- [x] Mỗi dòng nếu quá dài, cần xuống dòng (maximum: 80 kí tự mỗi dòng)
- [x] Xóa các file được tự động sinh ra khi dùng các câu lệnh rails generate ... tạo ra nhưng k dùng đến, không có dòng code nào được viết trong đó (hay gặp nhất là các file helper)
- [x] Khi tạo mảng, nên tích cực sử dụng %w( ), %i() . Thay vì STATES = ['draft', 'open', 'closed'] có thể dùng STATES = %w(draft open closed)
- [x] Xem các lỗi hay gặp khi triển khai Rails tutorial tại https://docs.google.com/document/d/104Csp4-vamVos5DEbi372nLBEfmqhj7h1ENYO8ebjCo/edit
- [x] Tham khảo coding convention https://github.com/framgia/coding-standards/blob/master/vn/README.md

## Related Tickets
https://edu-redmine.sun-asterisk.vn/issues/79515

## WHAT (optional)
- Thêm params cho thanh search
- Thêm màu cho các trạng thái
- I18n cho các trạng thái
- Thay đổi các trường hợp có nút hủy đặt sân
- Thêm toast

## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
![image](https://github.com/user-attachments/assets/f8f34c08-3bb1-426a-a976-987082c66217)
![image](https://github.com/user-attachments/assets/9570b038-2550-4e4e-909e-6270f96e9c7a)

## Notes (Kiến thức tìm hiểu thêm)
